### PR TITLE
docs: remove unnecessary quote in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ```yaml
 uses: raulanatol/jest-coverage-comment-action@main
 with:
-  github-token: ${{ secrets.GITHUB_TOKEN }}'
+  github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 # Example using a custom jest command and working directory


### PR DESCRIPTION
Just removing the unnecessary quote. I figured it out using the example.